### PR TITLE
repo-add: parse options and flags in arguments until "--" is reached

### DIFF
--- a/scripts/repo-add/src/parse_args.rs
+++ b/scripts/repo-add/src/parse_args.rs
@@ -11,8 +11,6 @@ pub struct ArgStruct {
     pub prevent_downgrade: bool,
     pub use_new_db_format: bool,
 
-    pub cmd_line: String,
-
     pub repo_db_file: Option<String>,
     pub repo_db_prefix: Option<String>,
     pub repo_db_suffix: Option<String>,
@@ -34,8 +32,6 @@ impl ArgStruct {
             prevent_downgrade: false,
             use_new_db_format: false,
 
-            cmd_line: String::new(),
-
             repo_db_file: None,
             repo_db_prefix: None,
             repo_db_suffix: None,
@@ -45,11 +41,11 @@ impl ArgStruct {
     }
 }
 
-pub fn parse_args(pargs: &[String]) -> (Option<&[String]>, ArgStruct) {
+pub fn parse_args(pargs: &mut Vec<String>) -> (Option<&[String]>, ArgStruct) {
     let mut argstruct = ArgStruct::new();
-    argstruct.cmd_line = crate::utils::get_current_cmdname(pargs[0].as_str()).to_owned();
+    pargs.remove(0);
 
-    let mut i = 1;
+    let mut i = 0;
     while i < pargs.len() {
         let argument = pargs[i].as_str();
         if argument == "--quiet" || argument == "-q" {
@@ -63,11 +59,12 @@ pub fn parse_args(pargs: &[String]) -> (Option<&[String]>, ArgStruct) {
         } else if argument == "--sign" || argument == "-s" {
             argstruct.sign = true;
         } else if argument == "--key" || argument == "-k" {
-            i += 1;
+            pargs.remove(i);
             if i < pargs.len() {
-                argstruct.gpgkey = Some(pargs[i].clone());
+                argstruct.gpgkey = Some(pargs.remove(i).clone());
                 argstruct.key = true;
             }
+            continue;
         } else if argument == "--verify" || argument == "-v" {
             argstruct.verify = true;
         } else if argument == "--prevent-downgrade" || argument == "-p" {
@@ -75,16 +72,14 @@ pub fn parse_args(pargs: &[String]) -> (Option<&[String]>, ArgStruct) {
         } else if argument == "--use-new-db-format" {
             argstruct.use_new_db_format = true;
         } else if argument == "--" {
-            i += 1;
+            pargs.remove(i);
             break;
         } else {
-            break;
+            i += 1;
+            continue;
         }
-        i += 1;
-    }
-    if i >= pargs.len() {
-        return (None, argstruct);
+        pargs.remove(i);
     }
 
-    (pargs.get(i..), argstruct)
+    (Some(pargs), argstruct)
 }


### PR DESCRIPTION
`utils::get_current_cmdname` is called right at the start of `main`, because of the fail-fast path that avoids `parse_args` for `--help`/`-h` and `--version`/`-V`. This means `cmd_line` can be reused for the rest of the lifetine of the program, and doesn't need to be in `ArgStruct` either.

After `parse_args`, nothing needs access to the "raw" `args` (just `cmd_line`), so make `args` mutable and pass it as a `Vec` into `parse_args`. `parse_args` can then pop flags and options from `pargs` until `--` is reached, thus behaving the same as vanilla repo-add.

---

I couldn't find a way to separate the `cmd_line` changes from the argument parsing ones, because of the borrow checker. I am unsure if this is the idiomatic way to do it, but from what I tested, it gets the job done.
